### PR TITLE
Fix toml section names in docs

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -28,7 +28,7 @@ your formatter only gets run on the latest enabled Python version:
 .. code-block:: toml
     :caption: pyproject.toml
 
-    [tool.thx.format]
+    [tool.thx.jobs.format]
     run = ["black {module}"]
     once = true
 
@@ -44,7 +44,7 @@ best use of multi-core systems:
 .. code-block:: toml
     :caption: pyproject.toml
 
-    [tool.thx.job.lint]
+    [tool.thx.jobs.lint]
     run = [
         "black --check {module}",
         "flake8 {module}",


### PR DESCRIPTION
### Description

Following the docs for setting up a new project, some of the section names didn't work.  This standardizes them to ones that do.