### PR TITLE
Exit with correct error code when venv creation fails

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ coverage==6.4.4
 flit==3.7.1
 flake8==5.0.4
 mypy==0.971
-sphinx==5.1.1
+sphinx==5.1.1; python_version >= "3.8"
 sphinx-mdinclude==0.5.1
 ufmt==2.0.1
 usort==1.0.5

--- a/thx/context.py
+++ b/thx/context.py
@@ -209,8 +209,10 @@ async def prepare_virtualenv(context: Context, config: Config) -> AsyncIterator[
 
             # upgrade pip
             yield VenvCreate(context, message="upgrading pip")
+            await check_command(
+                [context.python_path, "-m", "pip", "install", "-U", "pip", "setuptools"]
+            )
             pip = which("pip", context)
-            await check_command([pip, "install", "-U", "pip", "setuptools"])
 
             # install requirements.txt
             yield VenvCreate(context, message="installing requirements")

--- a/thx/core.py
+++ b/thx/core.py
@@ -6,7 +6,15 @@ import logging
 import signal
 from pathlib import Path
 from time import monotonic_ns
-from typing import Any, AsyncGenerator, AsyncIterable, AsyncIterator, List, Sequence
+from typing import (
+    Any,
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    List,
+    Sequence,
+    Union,
+)
 
 from aioitertools.asyncio import as_generated
 from trailrunner.core import gitignore, pathspec
@@ -126,7 +134,7 @@ def run(
     options: Options,
     render: Renderer = print,
 ) -> int:
-    results: List[Result] = []
+    results: List[Union[Result, VenvError]] = []
 
     config = options.config
     contexts = resolve_contexts(config, options)
@@ -145,7 +153,7 @@ def run(
         async for event in run_jobs(jobs, contexts, config):
             render(event)
 
-            if isinstance(event, Result):
+            if isinstance(event, (Result, VenvError)):
                 results.append(event)
 
     asyncio.run(runner())

--- a/thx/runner.py
+++ b/thx/runner.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+import platform
 import shlex
 import shutil
 from asyncio.subprocess import PIPE
@@ -24,7 +25,10 @@ LOG = logging.getLogger(__name__)
 
 
 def which(name: str, context: Context) -> str:
-    bin_path = (context.venv / "bin").as_posix()
+    if platform.system() == "Windows":
+        bin_path = (context.venv / "Scripts").as_posix()
+    else:
+        bin_path = (context.venv / "bin").as_posix()
     binary = shutil.which(name, path=bin_path)
     if binary is None:
         binary = shutil.which(name)

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -385,7 +385,17 @@ class ContextTest(TestCase):
 
             run_mock.assert_has_calls(
                 [
-                    call([pip, "install", "-U", "pip", "setuptools"]),
+                    call(
+                        [
+                            ctx.python_path,
+                            "-m",
+                            "pip",
+                            "install",
+                            "-U",
+                            "pip",
+                            "setuptools",
+                        ]
+                    ),
                     call([pip, "install", "-U", "-r", reqs]),
                     call([pip, "install", "-U", config.root]),
                 ]

--- a/thx/tests/runner.py
+++ b/thx/tests/runner.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Amethyst Reese
 # Licensed under the MIT License
 
+import platform
 import sys
 from pathlib import Path
 from unittest import skipIf, TestCase
@@ -15,17 +16,20 @@ class RunnerTest(TestCase):
     @patch("thx.runner.shutil.which")
     def test_which(self, which_mock: Mock) -> None:
         context = Context(Version("3.10"), Path(), Path("/fake/venv"))
+        fake_venv_bin = (
+            "/fake/venv/Scripts" if platform.system() == "Windows" else "/fake/venv/bin"
+        )
         with self.subTest("found"):
             which_mock.side_effect = lambda b, path: f"/usr/bin/{b}"
             self.assertEqual("/usr/bin/frobfrob", runner.which("frobfrob", context))
-            which_mock.assert_has_calls([call("frobfrob", path="/fake/venv/bin")])
+            which_mock.assert_has_calls([call("frobfrob", path=fake_venv_bin)])
 
         with self.subTest("not in venv"):
             which_mock.side_effect = [None, "/usr/bin/scoop"]
             self.assertEqual("/usr/bin/scoop", runner.which("scoop", context))
             which_mock.assert_has_calls(
                 [
-                    call("scoop", path="/fake/venv/bin"),
+                    call("scoop", path=fake_venv_bin),
                     call("scoop"),
                 ]
             )
@@ -36,7 +40,7 @@ class RunnerTest(TestCase):
             self.assertEqual("frobfrob", runner.which("frobfrob", context))
             which_mock.assert_has_calls(
                 [
-                    call("frobfrob", path="/fake/venv/bin"),
+                    call("frobfrob", path=fake_venv_bin),
                     call("frobfrob"),
                 ]
             )


### PR DESCRIPTION
### Description

Tracks VenvErrors similar to normal job results when running, allowing the CLI to exit with code 1 when a virtualenv fails setup. Also limits sphinx to Python 3.8+ to avoid conflicts with flake8 and importlib-metadata.

Fixes: #40, #53
