### PR TITLE
After creating venv, unconditionally find new binary.

### DIFF
--- a/thx/context.py
+++ b/thx/context.py
@@ -13,8 +13,7 @@ from typing import AsyncIterator, Dict, List, Optional, Sequence, Tuple
 
 from aioitertools.asyncio import as_generated
 
-from .runner import check_command, which
-
+from .runner import check_command
 from .types import (
     CommandError,
     Config,
@@ -27,8 +26,7 @@ from .types import (
     VenvReady,
     Version,
 )
-
-from .utils import timed, version_match
+from .utils import timed, venv_bin_path, version_match, which
 
 LOG = logging.getLogger(__name__)
 PYTHON_VERSION_RE = re.compile(r"Python (\d+\.\d+[a-zA-Z0-9-_.]+)\+?")
@@ -81,11 +79,13 @@ def find_runtime(
     version: Version, venv: Optional[Path] = None
 ) -> Tuple[Optional[Path], Optional[Version]]:
     if venv and venv.is_dir():
-        bin_dir = venv / "bin"
+        bin_dir = venv_bin_path(venv)
         if bin_dir.is_dir():
             binary_path_str = shutil.which("python", path=f"{bin_dir.as_posix()}")
             if binary_path_str:
-                return Path(binary_path_str), None
+                binary_path = Path(binary_path_str)
+                binary_version = runtime_version(binary_path)
+                return binary_path, binary_version
 
     # TODO: better way to find specific micro/pre/post versions?
     binary_names = [

--- a/thx/context.py
+++ b/thx/context.py
@@ -198,9 +198,6 @@ async def prepare_virtualenv(context: Context, config: Config) -> AsyncIterator[
                 import venv
 
                 venv.create(context.venv, prompt=prompt, with_pip=True)
-                new_python_path, _ = find_runtime(context.python_version, context.venv)
-                assert new_python_path is not None
-                context.python_path = new_python_path
 
             else:
                 await check_command(
@@ -213,6 +210,10 @@ async def prepare_virtualenv(context: Context, config: Config) -> AsyncIterator[
                         context.venv,
                     ]
                 )
+
+            new_python_path, _ = find_runtime(context.python_version, context.venv)
+            assert new_python_path is not None
+            context.python_path = new_python_path
 
             # upgrade pip
             yield VenvCreate(context, message="upgrading pip")

--- a/thx/context.py
+++ b/thx/context.py
@@ -80,12 +80,10 @@ def find_runtime(
 ) -> Tuple[Optional[Path], Optional[Version]]:
     if venv and venv.is_dir():
         bin_dir = venv_bin_path(venv)
-        LOG.debug("looking for runtime in venv %s", bin_dir)
         binary_path_str = shutil.which("python", path=bin_dir.as_posix())
         if binary_path_str:
             binary_path = Path(binary_path_str)
             binary_version = runtime_version(binary_path)
-            LOG.debug("found venv runtime %s", binary_path)
             return binary_path, binary_version
 
     # TODO: better way to find specific micro/pre/post versions?

--- a/thx/context.py
+++ b/thx/context.py
@@ -215,10 +215,8 @@ async def prepare_virtualenv(context: Context, config: Config) -> AsyncIterator[
             new_python_path, new_python_version = find_runtime(
                 context.python_version, context.venv
             )
-            assert new_python_path is not None
-            assert new_python_version is not None
-            context.python_path = new_python_path
-            context.python_version = new_python_version
+            context.python_path = new_python_path or context.python_path
+            context.python_version = new_python_version or context.python_version
 
             # upgrade pip
             yield VenvCreate(context, message="upgrading pip")

--- a/thx/runner.py
+++ b/thx/runner.py
@@ -4,12 +4,9 @@
 import asyncio
 import logging
 import os
-import platform
 import shlex
-import shutil
 from asyncio.subprocess import PIPE
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 
 from .types import (
@@ -22,26 +19,9 @@ from .types import (
     Step,
     StrPath,
 )
+from .utils import venv_bin_path, which
 
 LOG = logging.getLogger(__name__)
-
-
-def venv_bin_path(context: Context) -> Path:
-    if platform.system() == "Windows":
-        bin_path = context.venv / "Scripts"
-    else:
-        bin_path = context.venv / "bin"
-    return bin_path
-
-
-def which(name: str, context: Context) -> str:
-    bin_path = venv_bin_path(context).as_posix()
-    binary = shutil.which(name, path=bin_path)
-    if binary is None:
-        binary = shutil.which(name)
-        if binary is None:
-            return name
-    return binary
 
 
 def render_command(run: str, context: Context, config: Config) -> Sequence[str]:
@@ -58,7 +38,7 @@ async def run_command(
     new_env: Optional[Dict[str, str]] = None
     if context:
         new_env = os.environ.copy()
-        new_env["PATH"] = f"{venv_bin_path(context)}{os.pathsep}{new_env['PATH']}"
+        new_env["PATH"] = f"{venv_bin_path(context.venv)}{os.pathsep}{new_env['PATH']}"
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=PIPE, stderr=PIPE, env=new_env
     )

--- a/thx/tests/__main__.py
+++ b/thx/tests/__main__.py
@@ -2,11 +2,13 @@
 # Licensed under the MIT License
 
 import asyncio
+import logging
 import sys
 import unittest
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
     if sys.platform == "win32" and sys.version_info < (3, 8):
         loop = asyncio.ProactorEventLoop()
         asyncio.set_event_loop(loop)
-    unittest.main("thx.tests", verbosity=1)
+    unittest.main("thx.tests", verbosity=2)

--- a/thx/tests/__main__.py
+++ b/thx/tests/__main__.py
@@ -2,13 +2,11 @@
 # Licensed under the MIT License
 
 import asyncio
-import logging
 import sys
 import unittest
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
     if sys.platform == "win32" and sys.version_info < (3, 8):
         loop = asyncio.ProactorEventLoop()
         asyncio.set_event_loop(loop)
-    unittest.main("thx.tests", verbosity=2)
+    unittest.main("thx.tests", verbosity=1)

--- a/thx/tests/cli.py
+++ b/thx/tests/cli.py
@@ -60,8 +60,8 @@ class CliTest(TestCase):
             live_mock.return_value.reset_mock()
             render(event)
 
-            self.assertIn(ctx, render.venvs)
-            self.assertEqual(event, render.venvs[ctx])
+            self.assertIn(ctx.venv, render.venvs)
+            self.assertEqual(event, render.venvs[ctx.venv])
             live_mock.return_value.update.assert_called_once()
 
     def test_render_job(self, live_mock: MagicMock) -> None:

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -242,7 +242,6 @@ class ContextTest(TestCase):
                             ),
                         ]
                     )
-                    runtime_mock.assert_not_called()
 
     @patch("thx.context.find_runtime")
     def test_resolve_contexts_no_config(self, runtime_mock: Mock) -> None:

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -24,6 +24,7 @@ from ..types import (
     VenvReady,
     Version,
 )
+from ..utils import venv_bin_path
 
 TEST_VERSIONS = [
     Version(v)
@@ -228,9 +229,10 @@ class ContextTest(TestCase):
 
                 with self.subTest(version):
                     venv = context.venv_path(config, version)
-                    (venv / "bin").mkdir(parents=True, exist_ok=True)
+                    bin_dir = venv_bin_path(venv)
+                    bin_dir.mkdir(parents=True, exist_ok=True)
 
-                    expected = venv / "bin" / "python"
+                    expected = bin_dir / "python"
                     result, _ = context.find_runtime(version, venv)
                     self.assertEqual(expected, result)
 
@@ -238,7 +240,7 @@ class ContextTest(TestCase):
                         [
                             call(
                                 "python",
-                                path=(venv / "bin").as_posix(),
+                                path=bin_dir.as_posix(),
                             ),
                         ]
                     )

--- a/thx/tests/runner.py
+++ b/thx/tests/runner.py
@@ -1,51 +1,19 @@
 # Copyright 2022 Amethyst Reese
 # Licensed under the MIT License
 
-import platform
 import sys
 from asyncio.subprocess import PIPE
 from pathlib import Path
 from unittest import skipIf, TestCase
-from unittest.mock import ANY, call, Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from .. import runner
 from ..types import CommandError, CommandResult, Config, Context, Job, Result, Version
+from ..utils import venv_bin_path
 from .helper import async_test
 
 
 class RunnerTest(TestCase):
-    @patch("thx.runner.shutil.which")
-    def test_which(self, which_mock: Mock) -> None:
-        context = Context(Version("3.10"), Path(), Path("/fake/venv"))
-        fake_venv_bin = (
-            "/fake/venv/Scripts" if platform.system() == "Windows" else "/fake/venv/bin"
-        )
-        with self.subTest("found"):
-            which_mock.side_effect = lambda b, path: f"/usr/bin/{b}"
-            self.assertEqual("/usr/bin/frobfrob", runner.which("frobfrob", context))
-            which_mock.assert_has_calls([call("frobfrob", path=fake_venv_bin)])
-
-        with self.subTest("not in venv"):
-            which_mock.side_effect = [None, "/usr/bin/scoop"]
-            self.assertEqual("/usr/bin/scoop", runner.which("scoop", context))
-            which_mock.assert_has_calls(
-                [
-                    call("scoop", path=fake_venv_bin),
-                    call("scoop"),
-                ]
-            )
-
-        with self.subTest("not found"):
-            which_mock.side_effect = None
-            which_mock.return_value = None
-            self.assertEqual("frobfrob", runner.which("frobfrob", context))
-            which_mock.assert_has_calls(
-                [
-                    call("frobfrob", path=fake_venv_bin),
-                    call("frobfrob"),
-                ]
-            )
-
     @patch("thx.runner.which")
     def test_render_command(self, which_mock: Mock) -> None:
         which_mock.return_value = "/opt/bin/frobfrob"
@@ -54,7 +22,7 @@ class RunnerTest(TestCase):
         result = runner.render_command("frobfrob check {module}.tests", context, config)
         self.assertEqual(("/opt/bin/frobfrob", "check", "alpha.tests"), result)
 
-    @patch("thx.runner.shutil.which", return_value=None)
+    @patch("thx.utils.shutil.which", return_value=None)
     def test_prepare_job(self, which_mock: Mock) -> None:
         config = Config(values={"module": "beta"})
         context = Context(Version("3.9"), Path(), Path())
@@ -99,7 +67,7 @@ class RunnerTest(TestCase):
                 "/fake/binary", "something", stdout=PIPE, stderr=PIPE, env=ANY
             )
             self.assertIn(
-                str(runner.venv_bin_path(ctx)),
+                str(venv_bin_path(ctx.venv)),
                 exec_mock.call_args.kwargs["env"]["PATH"],
             )
 

--- a/thx/utils.py
+++ b/thx/utils.py
@@ -2,10 +2,13 @@
 # Licensed under the MIT License
 
 import logging
+import platform
+import shutil
 from asyncio import iscoroutinefunction
 from dataclasses import dataclass, field, replace
 from functools import wraps
 from itertools import zip_longest
+from pathlib import Path
 from time import monotonic_ns
 from typing import Any, Callable, List, Optional, TypeVar
 
@@ -107,6 +110,24 @@ def get_timings() -> List[timed]:
     result = list(sorted(TIMINGS))
     TIMINGS.clear()
     return result
+
+
+def venv_bin_path(venv: Path) -> Path:
+    if platform.system() == "Windows":
+        bin_path = venv / "Scripts"
+    else:
+        bin_path = venv / "bin"
+    return bin_path
+
+
+def which(name: str, context: Context) -> str:
+    bin_path = venv_bin_path(context.venv).as_posix()
+    binary = shutil.which(name, path=bin_path)
+    if binary is None:
+        binary = shutil.which(name)
+        if binary is None:
+            return name
+    return binary
 
 
 def version_match(versions: List[Version], target: Version) -> List[Version]:


### PR DESCRIPTION
### Description

On archlinux with no .thx cache, things are pretty broken, at least when running with an explciit version like `thx -v -p 3.9 test`.  It will create the `.thx/venv/3.9.18/` venv but not actually use it in the subsequent attempt to update pip since it only adjusts `context.python_path` in the live case.  Arch is special in that installing python doesn't imply installing pip automatically; venvs get it via ensurepip. I don't know if this occurs on other distros.

I think this is close to the right change, but find_runtime when passed a venv dir can still return a non-venv python and that should probably be more explicitly handled.

I think what this was doing before was either doing a --user upgrade or operating on a writable pyenv install, and not actually upgrading the one in the venv.  That's my only explanation for how this wasn't erroring out.