### PR TITLE
Include .thx virtualenv dir in default watchdog excludes

### DIFF
--- a/thx/core.py
+++ b/thx/core.py
@@ -174,6 +174,7 @@ class ThxWatchdogHandler(FileSystemEventHandler):
         ".mypy_cache",
         ".coverage*",
         "*.swp",
+        ".thx",
     ]
 
     def __init__(


### PR DESCRIPTION
This should help prevent changes to the virtualenvs triggering
new runs when using `thx --watch` mode.

Issue #71
