### PR TITLE
Apply default logic for venv symlink mode

### DIFF
--- a/thx/context.py
+++ b/thx/context.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License
 
 import logging
+import os
 import platform
 import re
 import shutil
@@ -196,7 +197,12 @@ async def prepare_virtualenv(context: Context, config: Config) -> AsyncIterator[
             if context.live:
                 import venv
 
-                venv.create(context.venv, prompt=prompt, with_pip=True)
+                venv.create(
+                    context.venv,
+                    prompt=prompt,
+                    with_pip=True,
+                    symlinks=(os.name != "nt"),
+                )
 
             else:
                 await check_command(


### PR DESCRIPTION
### Description

As described in #127, the command-line `python -m venv` has different defaults to the `venv.create()` function. In particular, symlinks are the default for `-m venv` except on Windows, while `venv.create()` defaults to `symlinks=False`.

This change duplicates the default values when invoking `venv.create()`.

Fixes: #127
