### PR TITLE
Install current project as editable

### DIFF
--- a/thx/context.py
+++ b/thx/context.py
@@ -245,7 +245,7 @@ async def prepare_virtualenv(context: Context, config: Config) -> AsyncIterator[
                 proj = f"{config.root}[{','.join(config.extras)}]"
             else:
                 proj = str(config.root)
-            await check_command([pip, "install", "-U", proj])
+            await check_command([pip, "install", "--editable", proj])
 
             # timestamp marker
             content = f"{time.time_ns()}\n"

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -411,7 +411,7 @@ class ContextTest(TestCase):
                             "setuptools",
                         ]
                     ),
-                    call([pip, "install", "-U", str(config.root) + "[more]"]),
+                    call([pip, "install", "--editable", str(config.root) + "[more]"]),
                 ],
             )
 
@@ -457,7 +457,7 @@ class ContextTest(TestCase):
                         ]
                     ),
                     call([pip, "install", "-U", "-r", reqs]),
-                    call([pip, "install", "-U", str(config.root)]),
+                    call([pip, "install", "--editable", str(config.root)]),
                 ]
             )
 


### PR DESCRIPTION
### Description

Add `--editable` instead of `-U` when `pip install`-ing the current project.

This ensures that re-running `thx test` etc. will test the current code on disk, rather than a copy, even if pyproject.toml hasn't changed (or a project version number).

Fixes: #125
