### PR TITLE
Add option to build with uv

### DIFF
--- a/thx/context.py
+++ b/thx/context.py
@@ -46,8 +46,9 @@ def venv_path(config: Config, version: Version) -> Path:
 
 
 def runtime_version(binary: Path) -> Optional[Version]:
-    """
-    Run `binary -V` and parse out the Python version string. Cache the result to avoid repeated calls.
+    """Load the version printed by the given Python interpreter.
+
+    Cache the result to avoid repeated calls.
     """
     if binary not in PYTHON_VERSIONS:
         try:
@@ -175,9 +176,10 @@ def identify_venv(venv_path: Path) -> Tuple[Path, Version]:
 
 @timed("resolve contexts")
 def resolve_contexts(config: Config, options: Options) -> List[Context]:
-    """
-    Turn each configured Python version into a Context with a local or discovered Python path.
-    If options.live is set or no versions are configured, we just use the host Python version.
+    """Build a list of contexts in which to run.
+
+    We evaluate the list of Python versions from config, as well as
+    command-line options refining the list.
     """
     builder = determine_builder(config)
 
@@ -235,9 +237,10 @@ def resolve_contexts(config: Config, options: Options) -> List[Context]:
 
 
 def project_requirements(config: Config) -> Sequence[Path]:
-    """
-    Return a list of requirements file paths, either from config.requirements or discovered
-    (i.e. requirements*.txt).
+    """Return a list of requirements file paths for the project.
+
+    If config.requirements is given, use those paths. Otherwise, search for
+    requirements*.txt files in the project root.
     """
     paths: List[Path] = []
     if config.requirements:

--- a/thx/context.py
+++ b/thx/context.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License
 
 import logging
+import os
 import platform
 import re
 import shutil
@@ -196,7 +197,12 @@ async def prepare_virtualenv(context: Context, config: Config) -> AsyncIterator[
             if context.live:
                 import venv
 
-                venv.create(context.venv, prompt=prompt, with_pip=True)
+                venv.create(
+                    context.venv,
+                    prompt=prompt,
+                    with_pip=True,
+                    symlinks=(os.name != "nt"),
+                )
 
             else:
                 await check_command(

--- a/thx/context.py
+++ b/thx/context.py
@@ -353,9 +353,7 @@ async def prepare_virtualenv_pip(
             )
 
         # Update runtime in context
-        context.new_python_path, context.new_python_version = identify_venv(
-            context.venv
-        )
+        context.python_path, context.python_version = identify_venv(context.venv)
 
         # Upgrade pip, setuptools
         yield VenvCreate(context, message="upgrading pip")
@@ -407,7 +405,7 @@ async def prepare_virtualenv_uv(
         # Create the venv with uv
         uv = shutil.which("uv")
         if not uv:
-            raise CommandError("uv not found on PATH, cannot build with uv")
+            raise ConfigError("uv not found on PATH, cannot build with uv")
 
         await check_command(
             [
@@ -418,15 +416,13 @@ async def prepare_virtualenv_uv(
                 (
                     str(context.python_path)
                     if context.python_path
-                    else context.python_version
+                    else str(context.python_version)
                 ),
                 str(context.venv),
             ]
         )
 
-        context.new_python_path, context.new_python_version = identify_venv(
-            context.venv
-        )
+        context.python_path, context.python_version = identify_venv(context.venv)
 
         # Install requirements
         requirements = project_requirements(config)

--- a/thx/runner.py
+++ b/thx/runner.py
@@ -39,6 +39,7 @@ async def run_command(
     if context:
         new_env = os.environ.copy()
         new_env["PATH"] = f"{venv_bin_path(context.venv)}{os.pathsep}{new_env['PATH']}"
+        new_env["VIRTUAL_ENV"] = str(context.venv)
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=PIPE, stderr=PIPE, env=new_env
     )
@@ -51,8 +52,10 @@ async def run_command(
     )
 
 
-async def check_command(command: Sequence[StrPath]) -> CommandResult:
-    result = await run_command(command)
+async def check_command(
+    command: Sequence[StrPath], context: Optional[Context] = None
+) -> CommandResult:
+    result = await run_command(command, context)
 
     if result.error:
         raise CommandError(command, result)

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -387,7 +387,7 @@ class ContextTest(TestCase):
             venv = tdp / ".thx" / "venv" / "3.9"
             venv.mkdir(parents=True)
 
-            identity_mock.return_value = (Version("3.9.21"), venv / 'bin/python3.9')
+            identity_mock.return_value = (Version("3.9.21"), venv / "bin/python3.9")
 
             config = Config(root=tdp, extras=["more"])
             ctx = Context(Version("3.9"), venv / "bin" / "python", venv)

--- a/thx/tests/context.py
+++ b/thx/tests/context.py
@@ -421,7 +421,9 @@ class ContextTest(TestCase):
     async def test_prepare_virtualenv_live(
         self, which_mock: Mock, run_mock: Mock
     ) -> None:
-        async def fake_check_command(cmd: Sequence[StrPath]) -> CommandResult:
+        async def fake_check_command(
+            cmd: Sequence[StrPath], context: Optional[Context] = None
+        ) -> CommandResult:
             return CommandResult(0, "", "")
 
         run_mock.side_effect = fake_check_command

--- a/thx/types.py
+++ b/thx/types.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License
 
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from shlex import quote
 from typing import (
@@ -66,6 +67,12 @@ class Job:
         self.requires = tuple(r.casefold() for r in self.requires)
 
 
+class Builder(Enum):
+    PIP = "pip"
+    UV = "uv"
+    AUTO = "auto"
+
+
 @dataclass
 class Config:
     root: Path = field(default_factory=Path.cwd)
@@ -76,6 +83,7 @@ class Config:
     requirements: Sequence[str] = field(default_factory=list)
     extras: Sequence[str] = field(default_factory=list)
     watch_paths: Set[Path] = field(default_factory=set)
+    builder: Builder = Builder.AUTO
 
     def __post_init__(self) -> None:
         self.default = tuple(d.casefold() for d in self.default)
@@ -84,8 +92,9 @@ class Config:
 @dataclass(unsafe_hash=True)
 class Context:
     python_version: Version
-    python_path: Path
+    python_path: Optional[Path]
     venv: Path
+    builder: Builder = Builder.PIP
     live: bool = False
 
 

--- a/thx/utils.py
+++ b/thx/utils.py
@@ -10,7 +10,7 @@ from functools import wraps
 from itertools import zip_longest
 from pathlib import Path
 from time import monotonic_ns
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, Iterable, List, Optional, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -130,7 +130,7 @@ def which(name: str, context: Context) -> str:
     return binary
 
 
-def version_match(versions: List[Version], target: Version) -> List[Version]:
+def version_match(versions: Iterable[Version], target: Version) -> List[Version]:
     matches: List[Version] = []
     for version in versions:
         if all(


### PR DESCRIPTION
### Description

* Add a config option `tool.thx.builder` e.g. `builder = "uv"`. Builder defaults to "auto", meaning use uv if available on `$PATH`.
* Add support for building venvs with `uv`
* Load version information from `pyvenv.cfg` instead of parsing `python -V`

### What's missing

* Tests for the uv path
* Documentation

Fixes: #133 
