### PR TITLE
Better error message when pyproject.toml is broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,21 +32,21 @@ dependencies = [
 dev = [
     "aioitertools==v0.11.0",
     "click==8.1.7",
-    "packaging==24.2",
+    "packaging==24.0",
     "rich==13.7.1",
     "tomli==2.0.1",
     "trailrunner==1.4.0",
     "typing_extensions == 4.12.0",
     "watchdog==4.0.1",
 
-    "attribution==1.8.0",
+    "attribution==1.7.1",
     "black==24.4.2",
     "build>=1.2",
-    "coverage==7.6.10",
+    "coverage==7.5.3",
     "flit==3.9.0",
-    "flake8==7.1.1",
+    "flake8==7.0.0",
     "mypy==1.10.0",
-    "ufmt==2.8.0",
+    "ufmt==2.6.0",
     "usort==1.0.8.post1",
 ]
 docs = [

--- a/thx/config.py
+++ b/thx/config.py
@@ -135,7 +135,7 @@ def load_config(path: Optional[Path] = None) -> Config:
     try:
         data = tomli.loads(content).get("tool", {}).get("thx", {})
     except tomli.TOMLDecodeError as error:
-        raise ConfigError(f"failure parsing pyproject.toml: {str(error)}") from error
+        raise ConfigError(f"failure parsing {pyproject}: {error}") from error
 
     default: List[str] = ensure_listish(data.pop("default", None), "tool.thx.default")
     jobs: List[Job] = parse_jobs(data.pop("jobs", {}))

--- a/thx/config.py
+++ b/thx/config.py
@@ -132,7 +132,10 @@ def load_config(path: Optional[Path] = None) -> Config:
         return Config(root=path)
 
     content = pyproject.read_text()
-    data = tomli.loads(content).get("tool", {}).get("thx", {})
+    try:
+        data = tomli.loads(content).get("tool", {}).get("thx", {})
+    except tomli.TOMLDecodeError as error:
+        raise ConfigError(f"failure parsing pyproject.toml: {str(error)}") from error
 
     default: List[str] = ensure_listish(data.pop("default", None), "tool.thx.default")
     jobs: List[Job] = parse_jobs(data.pop("jobs", {}))

--- a/thx/tests/config.py
+++ b/thx/tests/config.py
@@ -79,7 +79,9 @@ class ConfigTest(TestCase):
             line_length = 37[]  # should cause parse failure
             """
         ) as td:
-            with self.assertRaisesRegex(ConfigError, "failure parsing pyproject.toml"):
+            with self.assertRaisesRegex(
+                ConfigError, r"failure parsing .*pyproject\.toml"
+            ):
                 load_config(td)
 
     def test_empty_config(self) -> None:

--- a/thx/tests/config.py
+++ b/thx/tests/config.py
@@ -72,6 +72,16 @@ class ConfigTest(TestCase):
             result = load_config(td)
             self.assertEqual(expected, result)
 
+    def test_broken_config(self) -> None:
+        with fake_pyproject(
+            """
+            [tool.black]
+            line_length = 37[]  # should cause parse failure
+            """
+        ) as td:
+            with self.assertRaisesRegex(ConfigError, "failure parsing pyproject.toml"):
+                load_config(td)
+
     def test_empty_config(self) -> None:
         with fake_pyproject(
             """


### PR DESCRIPTION
### Description

Catches the parse error from tomli and wraps it in a ConfigError with an
error message making it clear that the error is from parsing `pyproject.toml`

Fixes: #135
